### PR TITLE
Fixed the reconnection algorithm in the JS API.

### DIFF
--- a/src/XSockets.Clients/XSockets.JavaScript/XSockets.latest.beta.js
+++ b/src/XSockets.Clients/XSockets.JavaScript/XSockets.latest.beta.js
@@ -612,6 +612,11 @@ XSockets.WebSocket = (function () {
             arrControllers.forEach(function (ctrl) {
                 if (self.hasOwnProperty(ctrl)) delete self[ctrl];
                
+                var ctrlIdx = self.controllerInstances.indexOf(ctrl);
+                if (ctrlIdx != -1) {
+                    self.controllerInstances.splice(ctrlIdx, 1);
+                }
+
                 self.controllerInstances.push(ctrl);
                 self[ctrl] = new XSockets.Controller(ctrl, self.webSocket);
                


### PR DESCRIPTION
Hi Uffe!

I have finally found this GitHub repo, so I can post my fixes directly to you! In the new reconnection API, there was a bug causing a controller to initialize twice (and exponentially growing) times after a reconnect. That should be fixed by this. Personally, I don't like the new reconnection API too much, as it seems unnatural to me that simply creating a new instance of the XSockets.WebSocket class does not work by default (as it is really straightforward to change this behaviour by changing one argument to the getInstance method). But OK, I will have to live with that.

It would be really nice, if I could have the same access to the C# sources for the server part. Then I could be probably much more useful to all of us. I know this is not possible, but just to mention:)

Hope this helps!

Jan
