### PR TITLE
Detect native websocket

### DIFF
--- a/src/XSockets.Clients/XSockets.JavaScript/XSockets.latest.js
+++ b/src/XSockets.Clients/XSockets.JavaScript/XSockets.latest.js
@@ -430,6 +430,7 @@ XSockets.Communcation = (function () {
         var queue = [];
         var webSocket;
         // detect if we are running on a native WebSocket.
+        // Looking for '[native code]' in most browsers and for [object WebSocketConstructor] in Safari and on iOS
         var websocketTest = window.WebSocket.toString();
         if (websocketTest.indexOf('[native code]') > -1 || websocketTest.indexOf('[object WebSocketConstructor]') > -1) {
             webSocket = new window.WebSocket(url, subprotocol);

--- a/src/XSockets.Clients/XSockets.JavaScript/XSockets.latest.js
+++ b/src/XSockets.Clients/XSockets.JavaScript/XSockets.latest.js
@@ -430,7 +430,8 @@ XSockets.Communcation = (function () {
         var queue = [];
         var webSocket;
         // detect if we are running on a native WebSocket.
-        if (window.WebSocket.toString().indexOf('[native code]') > -1) {
+        var websocketTest = window.WebSocket.toString();
+        if (websocketTest.indexOf('[native code]') > -1 || websocketTest.indexOf('[object WebSocketConstructor]') > -1) {
             webSocket = new window.WebSocket(url, subprotocol);
         } else {
 


### PR DESCRIPTION
A fix that prevents the script to crash when trying to reconnect on Safari and Mobile Safari and Chrome on iOS.