### PR TITLE
Update Network State check in Network.Android.cs

### DIFF
--- a/src/XSockets.Shared.Client/XSocketClient.Network.Android.cs
+++ b/src/XSockets.Shared.Client/XSocketClient.Network.Android.cs
@@ -14,6 +14,7 @@ namespace XSockets
 
         public void UpdateAndroidNetworkStatus()
         {
+            var currentState = _state;
             _state = NetworkState.Unknown;
 
             // Retrieve the connectivity manager service
@@ -35,7 +36,19 @@ namespace XSockets
             else
             {
                 _state = NetworkState.Offline;
-            }            
+            }
+            
+            //Check if the state has changed.
+            //if it has we want to update the network state and disconnect if state is now offline
+            if (currentState != _state)
+            {
+                if(this.Communication != null)
+                    this.Communication.UpdateNetworkState(_state);
+                if (currentState != _state && OnNetworkStatusChanged != null)
+                {
+                    OnNetworkStatusChanged(this, _state);
+                }
+            }       
         }
 
         public void AndroidNetworkWatcher()
@@ -60,18 +73,7 @@ namespace XSockets
 
         void NetworkStatusChanged(object sender, EventArgs e)
         {
-            var currentState = _state;
-            UpdateAndroidNetworkStatus();          
-
-            if (currentState != _state)
-            {
-                if(this.Communication != null)
-                    this.Communication.UpdateNetworkState(_state);
-                if (currentState != _state && OnNetworkStatusChanged != null)
-                {
-                    OnNetworkStatusChanged(this, _state);
-                }
-            }           
+            UpdateAndroidNetworkStatus();              
         }
     }
 


### PR DESCRIPTION
If the Network state was changed to offline before the NetworkStatusBroadcastReceiver received event, the socket would not disconnect because the state was already offline. this fixes that issue by moving the network state check, to the UpdateAndroidNetworkStatus method.
Now the network state will be updated to its correct state and is not relying on the NetworkStatusBroadcastReciever to fire event (which in some cases can take up to 10 seconds)